### PR TITLE
Fix topbar height

### DIFF
--- a/assets/css/bootster.css
+++ b/assets/css/bootster.css
@@ -1,5 +1,5 @@
 ﻿.admin              { top: 53px !important; z-index: 9; } 
-.topbar             { height:35px; }
+.topbar             { height:34px; }
 h4.page-title       { margin:0; margin-top:8px; }
 
     


### PR DESCRIPTION
When creating a custom theme, I discovered a 1px gap at the bottom of topbar.  This change corrects that issue by decreasing the height of topbar to 34px.
