### PR TITLE
Increase width of ControlContainer by 1px

### DIFF
--- a/skin.css
+++ b/skin.css
@@ -19,7 +19,7 @@
 /* Make the Control bar more mobile friendly */
 .ControlContainer {
     position: relative;
-    width: 726px;
+    width: 727px;
     height: 53px;
     margin: 0px auto;
 }


### PR DESCRIPTION
Increased width of ControlContainer by 1px to correct an issue in DNN 08.00.01 which causes the ControlEditPageMenu to float below the Control Bar area.
